### PR TITLE
fix: remove poetry.lock, not available in GH runner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN useradd -ms /bin/bash open-sourdough && \
   usermod -a -G video open-sourdough
 USER open-sourdough
 WORKDIR /code
-COPY poetry.lock pyproject.toml /code/
+COPY pyproject.toml /code/
 
 RUN poetry install
 COPY scripts scripts


### PR DESCRIPTION
Remove `poetry.lock` from Dockerfile, since the file is not in VS