### PR TITLE
docs: remove } character in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ The session number is stored in a database, and the images are stored on the fil
 | `OPEN_SOURDOUGH_DB_USER` | Yes | Database user |
 | `OPEN_SOURDOUGH_DB_PASSWORD` | Yes | Password for database user |
 | `OPEN_SOURDOUGH_DB_PORT` | Yes | Port of the database |
-}
 
 ## How to run it
 Check the [Makefile](Makefile).


### PR DESCRIPTION
Remove `}` character in README.